### PR TITLE
chore: add develocity-conventions convention plugin

### DIFF
--- a/develocity-conventions/build.gradle
+++ b/develocity-conventions/build.gradle
@@ -1,0 +1,68 @@
+plugins {
+    id 'groovy'
+    id 'java-gradle-plugin'
+    id 'maven-publish'
+    id 'signing'
+    id 'com.vanniktech.maven.publish' version '0.36.0'
+}
+
+group = 'io.kestra.gradle'
+version = rootProject.findProperty('version')
+println "Building ${project.group}:${project.name}:${project.version}"
+
+gradlePlugin {
+    plugins {
+        kestraDevelocityConventions {
+            id = 'io.kestra.gradle.develocity-conventions'
+            implementationClass = 'io.kestra.gradle.DevelocityConventionsPlugin'
+            displayName = 'Kestra Develocity Conventions'
+            description = 'Applies and configures Develocity build scans and remote build cache with Kestra conventions'
+        }
+    }
+}
+
+mavenPublishing {
+    publishToMavenCentral(true)
+    signAllPublications()
+    coordinates(project.group, project.name, project.version)
+    pom {
+        name = project.name
+        description = "${project.group}:${project.name}:${project.version}"
+        url = "https://github.com/kestra-io/gradle-plugin"
+        licenses {
+            license {
+                name = 'The Apache License, Version 2.0'
+                url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+            }
+        }
+        developers {
+            developer {
+                id = 'tchiotludo'
+                name = 'Dehon'
+                email = 'ldehon@kestra.io'
+            }
+        }
+        scm {
+            connection = 'scm:git:'
+            url = "https://github.com/kestra-io/gradle-plugin"
+        }
+    }
+}
+
+repositories {
+    mavenCentral()
+    gradlePluginPortal()
+}
+
+dependencies {
+    implementation 'com.gradle:develocity-gradle-plugin:4.4.0'
+    implementation 'com.gradle:common-custom-user-data-gradle-plugin:2.4.0'
+
+    testImplementation gradleTestKit()
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.9.3'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.9.3'
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/develocity-conventions/src/main/groovy/io/kestra/gradle/DevelocityConventionsPlugin.groovy
+++ b/develocity-conventions/src/main/groovy/io/kestra/gradle/DevelocityConventionsPlugin.groovy
@@ -1,0 +1,52 @@
+package io.kestra.gradle
+
+import org.gradle.api.initialization.Settings
+import org.gradle.api.Plugin
+import org.gradle.api.tasks.testing.Test
+
+class DevelocityConventionsPlugin implements Plugin<Settings> {
+
+    void apply(Settings settings) {
+        settings.pluginManager.apply('com.gradle.develocity')
+        settings.pluginManager.apply('com.gradle.common-custom-user-data-gradle-plugin')
+
+        def isCI = System.getenv('CI') != null
+
+        settings.buildCache {
+            remote(settings.develocity.buildCache) {
+                enabled = true
+                push = isCI
+            }
+        }
+
+        settings.develocity {
+            server = "https://develocity.kestra.io"
+            buildScan {
+                uploadInBackground = !isCI
+                publishing.onlyIf { it.authenticated }
+                buildScanPublished { scan ->
+                    if (isCI) {
+                        def payload = [
+                            timestamp   : new Date().toString(),
+                            taskNames   : settings.gradle.startParameter.taskNames,
+                            buildScanId : scan.buildScanId,
+                            buildScanUri: scan.buildScanUri.toString()
+                        ]
+                        settings.rootDir.toPath()
+                            .resolve("develocity-scan-output.ndjson")
+                            .toFile() << groovy.json.JsonOutput.toJson(payload) + System.lineSeparator()
+                    }
+                }
+            }
+        }
+
+        // Record each test task's max heap size as a build scan custom value
+        settings.gradle.allprojects { project ->
+            project.tasks.withType(Test).configureEach { t ->
+                t.doFirst {
+                    settings.develocity.buildScan.value("${t.path}#maxHeapSize", t.maxHeapSize)
+                }
+            }
+        }
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,3 +2,4 @@ rootProject.name = 'gradle-plugin'
 
 include 'inject-bom-versions'
 include 'spotless-conventions'
+include 'develocity-conventions'


### PR DESCRIPTION
 ### What changes are being made and why?                                                                                                                                                                                                                                                 
                  
  Adds a new `develocity-conventions` convention plugin to centralise Develocity build scan and remote                                                                                                                                                                                     
  build cache configuration. Previously this config was inlined directly in consuming repos — moving it
  here means it can be reused and updated in one place.                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                           
  - Adds `develocity-conventions` subproject implementing `Plugin<Settings>`                                                                                                                                                                                                               
  - Applies `com.gradle.develocity` (v4.4.0) and `com.gradle.common-custom-user-data-gradle-plugin` (v2.4.0)                                                                                                                                                                               
  - Configures Develocity server, remote build cache, authenticated build scan publishing, and records test heap sizes as build scan custom values                                                                                                                                         
  - Removes inactive `kestra_wip` build scan tag                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                           
  Ref kestra-io/kestra-ee#7127                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                           
  ---             

  ### How the changes have been QAed?

  Published locally via `./gradlew :develocity-conventions:publishToMavenLocal` and applied in the `kestra` repo — confirmed build scans publish to https://develocity.kestra.io