### PR TITLE
chore: tag-based release for gradle-plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,15 @@
+plugins {
+    id 'net.researchgate.release' version '3.1.0'
+}
+
+release {
+    preTagCommitMessage = 'update to version'
+    tagCommitMessage = 'tag version'
+    newVersionCommitMessage = 'update snapshot version'
+    tagTemplate = 'v${version}'
+    // Root is an empty aggregator with no build task; CI runs the full check on the tag.
+    buildTasks = []
+    git {
+        requireBranch.set('main')
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.0.2-SNAPSHOT
+version=1.2.0-SNAPSHOT


### PR DESCRIPTION
- Adds the release plugin at the root so `./gradlew` release bumps the version, tags v${version}, and pushes.
- the pushed tag triggers the existing publish workflow.

- Also corrects the stale root version from 1.0.2-SNAPSHOT to 1.2.0-SNAPSHOT: 1.0.2 was already released (current line is 1.1.0).
