### PR TITLE
fix: minor fixes plugin-doc-lint

### DIFF
--- a/plugin-doc-lint/src/main/groovy/io/kestra/gradle/LintPluginDocsTask.groovy
+++ b/plugin-doc-lint/src/main/groovy/io/kestra/gradle/LintPluginDocsTask.groovy
@@ -29,7 +29,7 @@ abstract class LintPluginDocsTask extends DefaultTask {
     @Classpath
     abstract ConfigurableFileCollection getPluginClasspath()
 
-    @InputFiles
+    @Classpath
     abstract ConfigurableFileCollection getClassesDirs()
 
     @Internal

--- a/plugin-doc-lint/src/main/groovy/io/kestra/gradle/rules/PluginRules.groovy
+++ b/plugin-doc-lint/src/main/groovy/io/kestra/gradle/rules/PluginRules.groovy
@@ -6,6 +6,7 @@ import io.kestra.gradle.model.PluginModel
 import io.kestra.gradle.model.Violation
 import io.kestra.gradle.scan.YamlSupport
 
+import java.util.regex.Matcher
 import java.util.regex.Pattern
 
 /**
@@ -18,6 +19,7 @@ import java.util.regex.Pattern
 class PluginRules {
 
     private static final Pattern LANG_YAML = ~/lang\s*=\s*"yaml"/
+    private static final Pattern PLUGIN_ANNOTATION = ~/@Plugin\s*\(/
 
     static List<Rule> rules() {
         return [
@@ -101,16 +103,9 @@ class PluginRules {
      */
     private static List<String> pluginAnnotationBlocks(String source) {
         List<String> blocks = []
-        int from = 0
-        while (true) {
-            int at = source.indexOf('@Plugin', from)
-            if (at < 0) {
-                break
-            }
-            int open = source.indexOf('(', at)
-            if (open < 0) {
-                break
-            }
+        Matcher matcher = PLUGIN_ANNOTATION.matcher(source)
+        while (matcher.find()) {
+            int open = matcher.end() - 1
             int depth = 0
             int i = open
             while (i < source.length()) {
@@ -127,7 +122,6 @@ class PluginRules {
                 i++
             }
             blocks << source.substring(open, Math.min(i, source.length()))
-            from = Math.max(i, at + '@Plugin'.length())
         }
         return blocks
     }

--- a/plugin-doc-lint/src/main/groovy/io/kestra/gradle/rules/RuleConstants.groovy
+++ b/plugin-doc-lint/src/main/groovy/io/kestra/gradle/rules/RuleConstants.groovy
@@ -25,7 +25,7 @@ class RuleConstants {
      * value-bearing cases.
      */
     static final List<String> SECRET_NAME_PATTERNS = [
-        'password', 'passphrase', 'apikey', 'privatekey', 'clientsecret',
+        'password', 'passphrase', 'apikey', 'privatekey', 'secretkey', 'clientsecret', 'jwtsecret',
         'apitoken', 'accesstoken', 'refreshtoken', 'authtoken', 'bearertoken', 'sessiontoken'
     ]
 

--- a/plugin-doc-lint/src/main/groovy/io/kestra/gradle/scan/YamlSupport.groovy
+++ b/plugin-doc-lint/src/main/groovy/io/kestra/gradle/scan/YamlSupport.groovy
@@ -1,6 +1,8 @@
 package io.kestra.gradle.scan
 
+import org.yaml.snakeyaml.LoaderOptions
 import org.yaml.snakeyaml.Yaml
+import org.yaml.snakeyaml.constructor.SafeConstructor
 import org.yaml.snakeyaml.error.YAMLException
 
 /**
@@ -19,7 +21,7 @@ class YamlSupport {
     /** Parse a YAML string into a Map, or null when it is invalid or not a mapping. */
     static Map<String, Object> parseMap(String text) {
         try {
-            Object loaded = new Yaml().load(text)
+            Object loaded = new Yaml(new SafeConstructor(new LoaderOptions())).load(text)
             if (loaded instanceof Map) {
                 return (Map<String, Object>) loaded
             }

--- a/plugin-doc-lint/src/test/groovy/io/kestra/gradle/rules/PropertyRulesTest.groovy
+++ b/plugin-doc-lint/src/test/groovy/io/kestra/gradle/rules/PropertyRulesTest.groovy
@@ -28,6 +28,15 @@ class PropertyRulesTest {
     }
 
     @Test
+    void 'PROP-002 flags value-bearing secret names'() {
+        ['secretKey', 'jwtSecret', 'clientSecret'].each { name ->
+            def c = task('io.kestra.plugin.acme.Run')
+            c.fields = [field(name, [hasPluginProperty: true, pluginPropertyGroup: 'connection'])]
+            assertEquals(1, run('PROP-002', model([c])).size(), "${name} should be flagged")
+        }
+    }
+
+    @Test
     void 'PROP-002 ignores secret-reference fields'() {
         // A field that names/points to a secret (arn, id) is not the secret value itself.
         ['secretArn', 'secretName', 'credentialId', 'pageToken'].each { name ->


### PR DESCRIPTION
Minor fixes in plugin-doc-lint.

- scope the PLUGIN-004 source scan to `@Plugin(` via regex, so `@PluginProperty` and `@PluginSubGroup` are not matched
- flag value-bearing secret names (`secretKey`, `jwtSecret`), keep ignoring references like `secretArn`/`credentialId`
- mark `classesDirs` with `@Classpath` for stable up-to-date checks across machines
- parse YAML with `SafeConstructor`
