### PR TITLE
docs: document the release process in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,3 +105,18 @@ Documentation (`src/main/resources/doc/`):
 PLUGIN-004 is checked against the source text, because reflection cannot tell an explicit
 `lang = "yaml"` from the default. META-003 requires `body` to be present but allows it to be
 empty, matching how current plugins ship it.
+
+## Releasing
+
+Releases are tag-based off `main`, using `net.researchgate.release`. To cut a release:
+
+```
+git checkout main && git pull
+./gradlew release
+```
+
+It bumps the version, tags `v<version>`, pushes, and bumps `main` to the next `-SNAPSHOT`. The
+pushed tag triggers CI, which publishes all modules to Maven Central and creates the GitHub
+release. One release versions all four plugins together.
+
+A new minor or major is just the next version number, no release branch needed.

--- a/README.md
+++ b/README.md
@@ -117,6 +117,6 @@ git checkout main && git pull
 
 It bumps the version, tags `v<version>`, pushes, and bumps `main` to the next `-SNAPSHOT`. The
 pushed tag triggers CI, which publishes all modules to Maven Central and creates the GitHub
-release. One release versions all four plugins together.
+release. One release versions all plugins together.
 
-A new minor or major is just the next version number, no release branch needed.
+A new patch, minor or major is just the next version number, no release branch needed.


### PR DESCRIPTION
Adds a short Releasing section to the README so the tag-based flow is documented in-repo.

`./gradlew release` on `main` bumps the version, tags `v<version>`, pushes, and bumps to the next snapshot. The tag triggers CI to publish all modules and create the GitHub release.