### PR TITLE
fix(plugin-doc-lint): exempt inherited framework annotations from value rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Icons (`src/main/resources/icons/`):
 | SCHEMA-002 | the class-level `@Schema` on a task or trigger has a non-empty `description` |
 | SCHEMA-003 | every non-static, non-transient field in a task, trigger, task runner or log exporter has `@Schema` |
 | SCHEMA-004 | every field in an output class has `@Schema` |
-| SCHEMA-005 | no `@Schema` `title` ends with a period |
+| SCHEMA-005 | no `@Schema` `title` ends with a period (titles inherited from a framework type the plugin cannot edit are exempt) |
 
 `@Plugin` / `@Example`:
 

--- a/plugin-doc-lint/src/main/groovy/io/kestra/gradle/model/FieldInfo.groovy
+++ b/plugin-doc-lint/src/main/groovy/io/kestra/gradle/model/FieldInfo.groovy
@@ -23,6 +23,14 @@ class FieldInfo {
     String schemaTitle
     String schemaDescription
 
+    /**
+     * True when the resolved {@code @Schema} is declared in the plugin's own code (on the field
+     * or a getter in an own class). False when it is only inherited from a framework type the
+     * plugin cannot edit (e.g. a core interface getter). Title-formatting rules apply only to
+     * own titles.
+     */
+    boolean schemaFromOwnCode = true
+
     boolean hasPluginProperty
     String pluginPropertyGroup
     boolean pluginPropertySecret

--- a/plugin-doc-lint/src/main/groovy/io/kestra/gradle/model/FieldInfo.groovy
+++ b/plugin-doc-lint/src/main/groovy/io/kestra/gradle/model/FieldInfo.groovy
@@ -34,4 +34,12 @@ class FieldInfo {
     boolean hasPluginProperty
     String pluginPropertyGroup
     boolean pluginPropertySecret
+
+    /**
+     * True when the resolved {@code @PluginProperty} is declared in the plugin's own code. False
+     * when it is only inherited from a framework type the plugin cannot edit (e.g. a core
+     * interface getter such as {@code PollingTriggerInterface.getInterval()}). Group/value rules
+     * apply only to own annotations.
+     */
+    boolean pluginPropertyFromOwnCode = true
 }

--- a/plugin-doc-lint/src/main/groovy/io/kestra/gradle/model/PluginModel.groovy
+++ b/plugin-doc-lint/src/main/groovy/io/kestra/gradle/model/PluginModel.groovy
@@ -36,6 +36,15 @@ class PluginModel {
     }
 
     /**
+     * Packages that contain at least one concrete task or trigger. PKG-003 uses this rather than
+     * {@link #packagesWithPlugins()} so a root-level log exporter or task runner alongside
+     * subpackaged tasks is not flagged as mixed task/trigger placement.
+     */
+    Set<String> packagesWithTasksOrTriggers() {
+        return classes.findAll { it.isConcreteTaskOrTrigger() }.collect { it.packageName }.toSet()
+    }
+
+    /**
      * Root package: the longest common dot-delimited prefix across all packages that
      * contain a plugin class. For a single-package plugin this is that package.
      */

--- a/plugin-doc-lint/src/main/groovy/io/kestra/gradle/rules/PackageRules.groovy
+++ b/plugin-doc-lint/src/main/groovy/io/kestra/gradle/rules/PackageRules.groovy
@@ -44,7 +44,9 @@ class PackageRules {
 
             new BaseRule('PKG-003', { PluginModel m ->
                 String root = m.rootPackage()
-                Set<String> pkgs = m.packagesWithPlugins()
+                // Only tasks/triggers count here (matching the rule's wording): a root-level log
+                // exporter or task runner is not "mixed task placement".
+                Set<String> pkgs = m.packagesWithTasksOrTriggers()
                 if (root != null && pkgs.size() > 1 && pkgs.contains(root)) {
                     return [new Violation('PKG-003', root,
                         "Tasks/triggers are placed in both the root package and subpackages. Move root-level tasks into a subpackage.")]

--- a/plugin-doc-lint/src/main/groovy/io/kestra/gradle/rules/PropertyRules.groovy
+++ b/plugin-doc-lint/src/main/groovy/io/kestra/gradle/rules/PropertyRules.groovy
@@ -15,7 +15,9 @@ class PropertyRules {
             new BaseRule('PROP-001', { PluginModel m ->
                 List<Violation> violations = []
                 m.documentablePlugins().each { ClassInfo c ->
-                    c.fields.findAll { it.hasPluginProperty }.each { FieldInfo f ->
+                    // Only own annotations: a group inherited from a framework type cannot be fixed in this plugin
+                    // (e.g. PollingTriggerInterface.getInterval() declares a bare @PluginProperty in core).
+                    c.fields.findAll { it.hasPluginProperty && it.pluginPropertyFromOwnCode }.each { FieldInfo f ->
                         if (!RuleConstants.PROPERTY_GROUPS.contains(f.pluginPropertyGroup)) {
                             violations << new Violation('PROP-001', "${f.declaringClassName ?: c.fqcn}#${f.name}",
                                 "@PluginProperty group '${f.pluginPropertyGroup ?: ''}' is not allowed. Use one of ${RuleConstants.PROPERTY_GROUPS.sort()}.")

--- a/plugin-doc-lint/src/main/groovy/io/kestra/gradle/rules/SchemaRules.groovy
+++ b/plugin-doc-lint/src/main/groovy/io/kestra/gradle/rules/SchemaRules.groovy
@@ -68,7 +68,8 @@ class SchemaRules {
                             "@Schema title ends with a period. Remove the trailing '.'.")
                     }
                     documentedFields(c).each { FieldInfo f ->
-                        if (endsWithPeriod(f.schemaTitle)) {
+                        // Only own titles: a title inherited from a framework type cannot be fixed in this plugin.
+                        if (f.schemaFromOwnCode && endsWithPeriod(f.schemaTitle)) {
                             violations << new Violation('SCHEMA-005', "${f.declaringClassName ?: c.fqcn}#${f.name}",
                                 "@Schema title ends with a period. Remove the trailing '.'.")
                         }

--- a/plugin-doc-lint/src/main/groovy/io/kestra/gradle/scan/ClassScanner.groovy
+++ b/plugin-doc-lint/src/main/groovy/io/kestra/gradle/scan/ClassScanner.groovy
@@ -201,11 +201,22 @@ class ClassScanner {
             }
         }
 
-        Annotation pp = find(field, PLUGIN_PROPERTY) ?: accessorAnnotation(owner, field.name, PLUGIN_PROPERTY)
+        Annotation pp = find(field, PLUGIN_PROPERTY)
         if (pp != null) {
+            // Declared on the field itself: the field belongs to an own class, so the annotation is own.
             info.hasPluginProperty = true
             info.pluginPropertyGroup = attrString(pp, 'group')
             info.pluginPropertySecret = (attr(pp, 'secret') ?: false) as boolean
+        } else {
+            Object[] accessor = accessorAnnotationAndOwner(owner, field.name, PLUGIN_PROPERTY)
+            if (accessor != null) {
+                pp = (Annotation) accessor[0]
+                info.hasPluginProperty = true
+                info.pluginPropertyGroup = attrString(pp, 'group')
+                info.pluginPropertySecret = (attr(pp, 'secret') ?: false) as boolean
+                // Inherited from a framework type (e.g. a core interface getter) the plugin cannot edit.
+                info.pluginPropertyFromOwnCode = ownClasses.contains((String) accessor[1])
+            }
         }
 
         return info

--- a/plugin-doc-lint/src/main/groovy/io/kestra/gradle/scan/ClassScanner.groovy
+++ b/plugin-doc-lint/src/main/groovy/io/kestra/gradle/scan/ClassScanner.groovy
@@ -189,6 +189,15 @@ class ClassScanner {
             info.hasSchema = true
             info.schemaTitle = attrString(schema, 'title')
             info.schemaDescription = attrString(schema, 'description')
+            // If the same property is also declared on an inherited (non-own) getter with the same title,
+            // the plugin is only echoing a framework-provided title it cannot change (e.g. Data.From.TITLE),
+            // so treat it as inherited and exempt it from title value-judgements like SCHEMA-005.
+            Object[] inherited = accessorAnnotationAndOwner(owner, field.name, SCHEMA)
+            if (inherited != null
+                && !ownClasses.contains((String) inherited[1])
+                && attrString((Annotation) inherited[0], 'title') == info.schemaTitle) {
+                info.schemaFromOwnCode = false
+            }
         } else {
             Object[] accessor = accessorAnnotationAndOwner(owner, field.name, SCHEMA)
             if (accessor != null) {

--- a/plugin-doc-lint/src/main/groovy/io/kestra/gradle/scan/ClassScanner.groovy
+++ b/plugin-doc-lint/src/main/groovy/io/kestra/gradle/scan/ClassScanner.groovy
@@ -138,7 +138,7 @@ class ClassScanner {
         }
 
         collectDeclaredFields(clazz, ownClasses).each { Field field ->
-            info.fields << toFieldInfo(clazz, field)
+            info.fields << toFieldInfo(clazz, field, ownClasses)
         }
 
         return info
@@ -174,7 +174,7 @@ class ClassScanner {
         return example
     }
 
-    private static FieldInfo toFieldInfo(Class<?> owner, Field field) {
+    private static FieldInfo toFieldInfo(Class<?> owner, Field field, Set<String> ownClasses) {
         FieldInfo info = new FieldInfo()
         info.name = field.name
         info.declaringClassName = field.declaringClass.name
@@ -183,11 +183,22 @@ class ClassScanner {
         info.isProperty = isProperty(owner, field)
 
         // @Schema and @PluginProperty may sit on the field or on its getter (interface-based config), so check both.
-        Annotation schema = find(field, SCHEMA) ?: accessorAnnotation(owner, field.name, SCHEMA)
+        Annotation schema = find(field, SCHEMA)
         if (schema != null) {
+            // Declared on the field itself: the field belongs to an own class, so the annotation is own.
             info.hasSchema = true
             info.schemaTitle = attrString(schema, 'title')
             info.schemaDescription = attrString(schema, 'description')
+        } else {
+            Object[] accessor = accessorAnnotationAndOwner(owner, field.name, SCHEMA)
+            if (accessor != null) {
+                schema = (Annotation) accessor[0]
+                info.hasSchema = true
+                info.schemaTitle = attrString(schema, 'title')
+                info.schemaDescription = attrString(schema, 'description')
+                // Inherited from a framework type (e.g. a core interface getter) the plugin cannot edit.
+                info.schemaFromOwnCode = ownClasses.contains((String) accessor[1])
+            }
         }
 
         Annotation pp = find(field, PLUGIN_PROPERTY) ?: accessorAnnotation(owner, field.name, PLUGIN_PROPERTY)
@@ -202,6 +213,16 @@ class ClassScanner {
 
     /** The annotation {@code fqn} on the field's getter (getX/isX), searched across superclasses and interfaces. */
     private static Annotation accessorAnnotation(Class<?> owner, String fieldName, String fqn) {
+        Object[] result = accessorAnnotationAndOwner(owner, fieldName, fqn)
+        return result == null ? null : (Annotation) result[0]
+    }
+
+    /**
+     * The annotation {@code fqn} on the field's getter (getX/isX) and the name of the class that
+     * declares it, searched across superclasses and interfaces. Returns {@code [annotation, declaringClassName]}
+     * or {@code null}. The declaring class name lets callers tell an own annotation from an inherited one.
+     */
+    private static Object[] accessorAnnotationAndOwner(Class<?> owner, String fieldName, String fqn) {
         if (!fieldName) {
             return null
         }
@@ -220,7 +241,7 @@ class ClassScanner {
                     if (m.parameterCount == 0 && names.contains(m.name)) {
                         Annotation a = m.declaredAnnotations.find { it.annotationType().name == fqn }
                         if (a != null) {
-                            return a
+                            return [a, current.name] as Object[]
                         }
                     }
                 }

--- a/plugin-doc-lint/src/test/groovy/io/kestra/gradle/Fixtures.groovy
+++ b/plugin-doc-lint/src/test/groovy/io/kestra/gradle/Fixtures.groovy
@@ -53,6 +53,7 @@ class Fixtures {
         f.hasSchema = opts.get('hasSchema', false)
         f.schemaTitle = opts.get('schemaTitle')
         f.schemaDescription = opts.get('schemaDescription')
+        f.schemaFromOwnCode = opts.get('schemaFromOwnCode', true)
         f.hasPluginProperty = opts.get('hasPluginProperty', false)
         f.pluginPropertyGroup = opts.get('pluginPropertyGroup')
         f.pluginPropertySecret = opts.get('pluginPropertySecret', false)

--- a/plugin-doc-lint/src/test/groovy/io/kestra/gradle/Fixtures.groovy
+++ b/plugin-doc-lint/src/test/groovy/io/kestra/gradle/Fixtures.groovy
@@ -57,6 +57,7 @@ class Fixtures {
         f.hasPluginProperty = opts.get('hasPluginProperty', false)
         f.pluginPropertyGroup = opts.get('pluginPropertyGroup')
         f.pluginPropertySecret = opts.get('pluginPropertySecret', false)
+        f.pluginPropertyFromOwnCode = opts.get('pluginPropertyFromOwnCode', true)
         return f
     }
 

--- a/plugin-doc-lint/src/test/groovy/io/kestra/gradle/PluginDocLintPluginTest.groovy
+++ b/plugin-doc-lint/src/test/groovy/io/kestra/gradle/PluginDocLintPluginTest.groovy
@@ -328,4 +328,49 @@ class PluginDocLintPluginTest {
         assertFalse(result.output.contains('One#shared'))
         assertFalse(result.output.contains('Two#shared'))
     }
+
+    @Test
+    void 'SCHEMA-005 exempts an own field title that only echoes a non-own inherited getter title'() {
+        // A subproject stands in for kestra-core: its types are on the classpath but NOT in this
+        // plugin's classesDirs, so they are non-own (the plugin author cannot change them).
+        settingsFile.text = "rootProject.name = 'test-plugin'\ninclude 'framework'"
+        file('framework/build.gradle').text = "plugins { id 'java' }\n"
+        file('framework/src/main/java/io/swagger/v3/oas/annotations/media/Schema.java').text = '''
+            package io.swagger.v3.oas.annotations.media;
+            import java.lang.annotation.*;
+            @Retention(RetentionPolicy.RUNTIME)
+            @Target({ElementType.TYPE, ElementType.FIELD, ElementType.METHOD})
+            public @interface Schema { String title() default ""; String description() default ""; }
+        '''.stripIndent()
+        // Non-own interface whose getter title ends with a period (mirrors core's Data.From.TITLE).
+        file('framework/src/main/java/io/kestra/core/models/property/StructuredFrom.java').text = '''
+            package io.kestra.core.models.property;
+            import io.swagger.v3.oas.annotations.media.Schema;
+            public interface StructuredFrom {
+                String TITLE = "Structured data items, as a map, a list, a URI, or a JSON string.";
+                @Schema(title = TITLE)
+                Object getFrom();
+            }
+        '''.stripIndent()
+        applyPlugin("pluginDocLint { ignoreFailures = true }\ndependencies { implementation project(':framework') }")
+        // 'from' re-declares the inherited title verbatim (echo); 'other' is a genuinely-own period title.
+        file('src/main/java/io/kestra/plugin/acme/Produce.java').text = '''
+            package io.kestra.plugin.acme;
+            import io.kestra.core.models.tasks.Task;
+            import io.kestra.core.models.property.StructuredFrom;
+            import io.swagger.v3.oas.annotations.media.Schema;
+            public class Produce implements Task, StructuredFrom {
+                @Schema(title = "Structured data items, as a map, a list, a URI, or a JSON string.")
+                public Object from;
+                @Schema(title = "A genuinely own title.")
+                public String other;
+                public Object getFrom() { return from; }
+            }
+        '''.stripIndent()
+        def result = runner('lintPluginDocs').build()
+        // Echoed inherited title -> exempt; genuinely-own period title -> still flagged.
+        assertFalse(result.output.contains('#from'))
+        assertTrue(result.output.contains('SCHEMA-005'))
+        assertTrue(result.output.contains('#other'))
+    }
 }

--- a/plugin-doc-lint/src/test/groovy/io/kestra/gradle/PluginDocLintPluginTest.groovy
+++ b/plugin-doc-lint/src/test/groovy/io/kestra/gradle/PluginDocLintPluginTest.groovy
@@ -284,6 +284,31 @@ class PluginDocLintPluginTest {
     }
 
     @Test
+    void 'SCHEMA-005 flags a period in a title on an own interface getter'() {
+        applyPlugin('pluginDocLint { ignoreFailures = true }')
+        // The interface is part of the plugin's own code, so its title is the author's to fix.
+        file('src/main/java/io/kestra/plugin/acme/HasRegion.java').text = '''
+            package io.kestra.plugin.acme;
+            import io.swagger.v3.oas.annotations.media.Schema;
+            public interface HasRegion {
+                @Schema(title = "The region.")
+                String getRegion();
+            }
+        '''.stripIndent()
+        file('src/main/java/io/kestra/plugin/acme/Reverse.java').text = '''
+            package io.kestra.plugin.acme;
+            import io.kestra.core.models.tasks.Task;
+            public class Reverse implements Task, HasRegion {
+                public String region;
+                public String getRegion() { return region; }
+            }
+        '''.stripIndent()
+        def result = runner('lintPluginDocs').build()
+        assertTrue(result.output.contains('SCHEMA-005'))
+        assertTrue(result.output.contains('#region'))
+    }
+
+    @Test
     void 'inherited field is reported once at its declaring class'() {
         applyPlugin('pluginDocLint { ignoreFailures = true }')
         file('src/main/java/io/kestra/plugin/acme/Base.java').text = '''

--- a/plugin-doc-lint/src/test/groovy/io/kestra/gradle/rules/PackageRulesTest.groovy
+++ b/plugin-doc-lint/src/test/groovy/io/kestra/gradle/rules/PackageRulesTest.groovy
@@ -53,4 +53,14 @@ class PackageRulesTest {
         ])
         assertTrue(run('PKG-003', m).isEmpty())
     }
+
+    @Test
+    void 'PKG-003 ignores a root log exporter alongside subpackaged tasks'() {
+        // a log exporter (or task runner) at the root is not "mixed task/trigger placement".
+        def m = model([
+            logExporter('io.kestra.plugin.acme.MyExporter'),
+            task('io.kestra.plugin.acme.events.Search')
+        ])
+        assertTrue(run('PKG-003', m).isEmpty())
+    }
 }

--- a/plugin-doc-lint/src/test/groovy/io/kestra/gradle/rules/PropertyRulesTest.groovy
+++ b/plugin-doc-lint/src/test/groovy/io/kestra/gradle/rules/PropertyRulesTest.groovy
@@ -19,6 +19,22 @@ class PropertyRulesTest {
     }
 
     @Test
+    void 'PROP-001 ignores a bad group inherited from a framework type'() {
+        // e.g. PollingTriggerInterface.getInterval() declares a bare @PluginProperty in core;
+        // the plugin cannot fix that group, so it must not be flagged.
+        def c = task('io.kestra.plugin.acme.MyTrigger')
+        c.fields = [field('interval', [hasPluginProperty: true, pluginPropertyGroup: '', pluginPropertyFromOwnCode: false])]
+        assertTrue(run('PROP-001', model([c])).isEmpty())
+    }
+
+    @Test
+    void 'PROP-001 still flags an own bad group'() {
+        def c = task('io.kestra.plugin.acme.Bad')
+        c.fields = [field('host', [hasPluginProperty: true, pluginPropertyGroup: '', pluginPropertyFromOwnCode: true])]
+        assertEquals(1, run('PROP-001', model([c])).size())
+    }
+
+    @Test
     void 'PROP-001 ignores output fields'() {
         // a group organizes the input form, so it is meaningless on an output result field.
         def o = output('io.kestra.plugin.acme.Run$Output')

--- a/plugin-doc-lint/src/test/groovy/io/kestra/gradle/rules/SchemaRulesTest.groovy
+++ b/plugin-doc-lint/src/test/groovy/io/kestra/gradle/rules/SchemaRulesTest.groovy
@@ -81,4 +81,20 @@ class SchemaRulesTest {
         def v = run('SCHEMA-005', model([c, out]))
         assertEquals(2, v.size())
     }
+
+    @Test
+    void 'SCHEMA-005 ignores a period in a title inherited from a framework type'() {
+        // e.g. a field implementing a core interface whose getter @Schema title ends with a period;
+        // the plugin cannot edit core, so the title must not be flagged.
+        def c = task('io.kestra.plugin.acme.Run')
+        c.fields = [field('outputFiles', [hasSchema: true, schemaTitle: 'Files to send to internal storage.', schemaFromOwnCode: false])]
+        assertTrue(run('SCHEMA-005', model([c])).isEmpty())
+    }
+
+    @Test
+    void 'SCHEMA-005 still flags an own field title ending with a period'() {
+        def c = task('io.kestra.plugin.acme.Run')
+        c.fields = [field('format', [hasSchema: true, schemaTitle: 'The format.', schemaFromOwnCode: true])]
+        assertEquals(1, run('SCHEMA-005', model([c])).size())
+    }
 }


### PR DESCRIPTION
Fixes false positives in plugin-doc-lint found during the org-wide rollout. Three independent fixes:

## 1. SCHEMA-005 — inherited @Schema titles
A field can inherit its `@Schema` from a core interface getter (e.g. `OutputFilesInterface.getOutputFiles()` whose title ends with a period). The plugin can't edit core, so it must not be flagged. The scanner now records whether a resolved annotation is declared in the plugin's own code; SCHEMA-005 only flags own titles. SCHEMA-003/004 presence checks are unchanged (an inherited `@Schema` still documents the field).

## 2. PROP-001 — inherited @PluginProperty group
Same inherited-from-core problem: `PollingTriggerInterface.getInterval()` declares a bare `@PluginProperty` (no group) in core, which trips PROP-001 on every polling trigger. PROP-001 now only checks own `@PluginProperty` annotations.

## 3. PKG-003 — only tasks/triggers, not log exporters / task runners
PKG-003's message is "Tasks/triggers are placed in both the root and subpackages", but it used `packagesWithPlugins()`, which also includes log exporters and task runners. A plugin with a root-level `LogExporter` plus subpackaged tasks (e.g. plugin-ee-splunk) was wrongly flagged. It now keys on concrete tasks/triggers only.

## Tests
Unit + TestKit coverage for each: inherited title/group not flagged while own ones still are; a root log-exporter alongside subpackaged tasks passes PKG-003. Verified end-to-end against plugin-ai, plugin-cassandra, and plugin-ee-splunk.

Pairs with a kestra-core change dropping the trailing period from `Data.From.TITLE` (the only constant-valued @Schema title in the catalog).

Unblocks the large bucket of plugins that only failed on these inherited/over-broad checks.